### PR TITLE
Make button texts and urls translatable with WPML.

### DIFF
--- a/ssb-main.php
+++ b/ssb-main.php
@@ -21,11 +21,8 @@ class ssb_main {
 		// Migration
 		add_action('init', array($this, 'ssb_icons_migration'));
 
-		// User interfaces object
-		$this->ui = new ssb_ui;
-
-		// Pull stored data
-		$this->settings = get_option( 'ssb_settings' );
+		// Initialize plugin
+		add_action( 'init', array( $this, 'ssb_init' ) );
 
 		// Plugin text domain
 		add_action( 'init', array( $this, 'ssb_textdomain' ) );
@@ -41,9 +38,6 @@ class ssb_main {
 
 		// Admin notices
 		add_action( 'admin_notices', array( $this, 'ssb_admin_notices' ) );
-
-		// Icons UI
-		add_action( 'wp_footer', array( $this->ui, 'icons' ) );
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'ssb_ui_assets' ) );
 
@@ -61,6 +55,24 @@ class ssb_main {
 	public function ssb_textdomain() {
 
 		load_plugin_textdomain( 'sticky-side-buttons', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+
+	}
+
+
+	/**
+	 * Initialize settings and ui
+	 *
+	 */
+	public function ssb_init() {
+
+		// User interfaces object
+		$this->ui = new ssb_ui;
+
+		// Pull stored data
+		$this->settings = get_option( 'ssb_settings' );
+
+		// Icons UI
+		add_action( 'wp_footer', array( $this, 'icons' ) );
 
 	}
 

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,12 @@
+<wpml-config>
+    <admin-texts>
+        <key name="ssb_buttons">
+                    <key name="btns">
+                        <key name="*">
+                            <key name="btn_text" />
+                            <key name="btn_link" />
+                        </key>
+                    </key>
+        </key>
+    </admin-texts>
+</wpml-config>


### PR DESCRIPTION
Hi, this is David from the WPML compatibility team. We have had a support request regarding the translation of your plugin and came up with the following pull request to satisfy the need.

The merge request consists of:

- a wpml-config.xml file that tells WPML which elements need to be translated.

- moved some code from the constructor to the 'init' hook, so that WPML has had the chance to hook into get_option to give you translated strings.

The issue was originally reported in our support forum:
https://wpml.org/forums/topic/how-to-translate-customdynamic-string-in-stickybuttons-plugin